### PR TITLE
add additional arguments and env vars for configuration. use MQTTv5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-slim-bookworm
 
+ARG TARGETPLATFORM
+
 RUN pip install --upgrade pip
 RUN adduser worker
 
@@ -8,7 +10,12 @@ USER worker
 WORKDIR /home/worker
 
 COPY --chown=worker:worker requirements.txt ./
-RUN pip install --user --no-cache-dir -r requirements.txt
+RUN if [ "${TARGETPLATFORM}" == "linux/arm/v7" ]; then \
+  MSGPACK_PUREPYTHON=1 pip install --user --no-cache-dir -r requirements.txt; \
+  else \
+  pip install --user --no-cache-dir -r requirements.txt; \
+  fi
+
 COPY --chown=worker:worker . ./
 
 ENV PATH="/home/worker/.local/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN  apt-get update && apt-get install build-essential -y
 
 RUN pip install --upgrade pip
 
-RUN if [ "${TARGETPLATFORM}" == "linux/arm/v7" ]; then \
+RUN if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then \
   MSGPACK_PUREPYTHON=1 pip install --user --no-cache-dir -r requirements.txt; \
   else \
   pip install --user --no-cache-dir -r requirements.txt; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,26 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.12-bookworm AS builder
 
 ARG TARGETPLATFORM
 
+COPY requirements.txt .
+
+RUN  apt-get update && apt-get install build-essential -y
+
 RUN pip install --upgrade pip
-RUN adduser worker
 
-USER worker
-
-WORKDIR /home/worker
-
-COPY --chown=worker:worker requirements.txt ./
 RUN if [ "${TARGETPLATFORM}" == "linux/arm/v7" ]; then \
   MSGPACK_PUREPYTHON=1 pip install --user --no-cache-dir -r requirements.txt; \
   else \
   pip install --user --no-cache-dir -r requirements.txt; \
   fi
 
+FROM python:3.12-slim-bookworm 
+
+RUN adduser worker
+USER worker
+WORKDIR /home/worker
+
+COPY --from=builder --chown=worker:worker /root/.local ./
 COPY --chown=worker:worker . ./
 
 ENV PATH="/home/worker/.local/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM python:3.12-slim-bookworm
 RUN pip install --upgrade pip
 RUN adduser worker
 
+USER worker
+
 WORKDIR /home/worker
 
-COPY --chown=worker:worker requirements.txt requirements.txt
+COPY --chown=worker:worker requirements.txt ./
 RUN pip install --user --no-cache-dir -r requirements.txt
 COPY --chown=worker:worker . ./
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,8 +1,4 @@
 {
-    canbus: {
-        channel: "vcan0",
-        interface: "socketcan_ctypes"
-    },
     canopen: {
         sync_interval: 10,
         sync_count: 6,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 json-cfg
 parse
-python-can==3.3.*
+python-can
 paho-mqtt


### PR DESCRIPTION
Add env vars and parameters for interface, log level, clientid, mqtt server and auth options, and more
use MQTTv5 instead of v31