### PR TITLE
Add BMS settings read/write over CAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,12 @@ For logging [python logging](https://docs.python.org/3/library/logging.html) is 
 The special section `canopen` allows to configure the bridge to send some [CANopen](https://en.wikipedia.org/wiki/CANopen) specific messages.
 If `sync_interval` is specified a sync message is sent every interval seconds. If `sync_count` is specified the sync message has one data byte that cyclicly counts from 0 to the given count.
 If `auto_start` is true the program listens to CANopen NMT bootup and heartbeat messages and sends a start command to every node that indicates it is not in operational mode.
+
+# BMS settings (read/write multi-frame)
+The optional `bms_settings` section enables reading and modifying BMS user-configurable settings that live in a multi-frame CAN payload (one read command, N response frames; writes resend the full payload as N frames).
+
+On startup, can2mqtt sends `read_request_canid` with `read_request_data` and listens for `frame_count` consecutive frames starting at `read_response_base`. Each entry in `settings` describes which byte slice (`frame_offset`, `byte_offset`, `size`, `signed`) of the assembled payload carries that value and how to scale it (`scale`); the decoded engineering value is published retained to `{state_topic_prefix}/{name}`.
+
+To modify a value, publish the new engineering value (as a string) to `{state_topic_prefix}/{name}{command_topic_suffix}`. The module updates its in-memory cache and resends all `frame_count` frames starting at `write_base`. Reserved/unknown bytes from the last read are preserved unchanged. **Writes that arrive before a successful read are dropped with an error**, since sending a partial payload could misconfigure the BMS. Publish to `refresh_topic` to re-issue the read request at any time.
+
+If a `hadiscovery.payload` is configured, every setting is automatically added as a Home Assistant `number` component, plus a `button` for the refresh topic. See `config.json.example` for the per-entry schema.

--- a/can2mqtt/bms_settings.py
+++ b/can2mqtt/bms_settings.py
@@ -1,0 +1,251 @@
+"""
+BMS settings read/write over CAN, exposed to MQTT and Home Assistant.
+
+The BMS uses a multi-frame protocol for its user-configurable settings:
+- Read: send 0x500 with data AA AA 02 00 FF FF FF FF; BMS responds with
+  `frame_count` frames starting at `read_response_base` (e.g. 0x450..0x45A).
+- Write: send `frame_count` frames starting at `write_base` (e.g. 0x410..0x41A)
+  containing the full settings payload.
+
+Because writes require the full payload, this module caches the most recent
+read and only allows writes after a successful read has populated the cache.
+"""
+
+import logging
+import math
+import threading
+import time
+
+import can
+
+
+class BmsSettings(can.Listener):
+    def __init__(self, cfg, bus, client, fallback_unique_id_prefix):
+        self.bus = bus
+        self.client = client
+        self.read_request_canid = _as_int(cfg.get("read_request_canid", "0x500"))
+        self.read_request_data = bytes.fromhex(
+            cfg.get("read_request_data", "AAAA0200FFFFFFFF").replace(" ", "")
+        )
+        self.read_response_base = _as_int(cfg.get("read_response_base", "0x450"))
+        self.write_base = _as_int(cfg.get("write_base", "0x410"))
+        self.frame_count = int(cfg.get("frame_count", 11))
+        self.state_topic_prefix = cfg.get("state_topic_prefix", "bms/settings")
+        self.command_topic_suffix = cfg.get("command_topic_suffix", "/set")
+        self.refresh_topic = cfg.get("refresh_topic", "bms/settings/refresh")
+        self.inter_frame_delay = float(cfg.get("inter_frame_delay_ms", 10)) / 1000.0
+        self.assembly_timeout = float(cfg.get("assembly_timeout_s", 2.0))
+        self.unique_id_prefix = cfg.get("unique_id_prefix", fallback_unique_id_prefix)
+
+        self.settings = {}
+        for name, entry in (cfg.get("settings") or {}).items():
+            self.settings[name] = {
+                "frame_offset": int(entry["frame_offset"]),
+                "byte_offset": int(entry["byte_offset"]),
+                "size": int(entry["size"]),
+                "signed": bool(entry.get("signed", False)),
+                "scale": float(entry.get("scale", 1.0)),
+                "unit": entry.get("unit"),
+                "min": entry.get("min"),
+                "max": entry.get("max"),
+                "step": entry.get("step"),
+                "device_class": entry.get("device_class"),
+                "friendly_name": entry.get("friendly_name", name),
+            }
+
+        self._lock = threading.Lock()
+        self._raw_frames = [None] * self.frame_count
+        self._first_frame_at = None
+        self.cache = {}
+        self.cache_ready = False
+
+    # ------------------------------------------------------------------ CAN side
+
+    def on_message_received(self, msg):
+        idx = msg.arbitration_id - self.read_response_base
+        if not (0 <= idx < self.frame_count):
+            return
+        with self._lock:
+            now = time.monotonic()
+            if self._first_frame_at is not None and now - self._first_frame_at > self.assembly_timeout:
+                self._raw_frames = [None] * self.frame_count
+                self._first_frame_at = None
+            if all(f is None for f in self._raw_frames):
+                self._first_frame_at = now
+            self._raw_frames[idx] = bytes(msg.data).ljust(8, b"\x00")[:8]
+            if all(f is not None for f in self._raw_frames):
+                self._decode_and_publish_locked()
+                self._first_frame_at = None
+
+    def _decode_and_publish_locked(self):
+        new_cache = {}
+        for name, e in self.settings.items():
+            frame = self._raw_frames[e["frame_offset"]]
+            raw = int.from_bytes(
+                frame[e["byte_offset"] : e["byte_offset"] + e["size"]],
+                "big",
+                signed=e["signed"],
+            )
+            new_cache[name] = raw * e["scale"]
+        self.cache = new_cache
+        self.cache_ready = True
+        logging.info("BMS settings cache populated (%d entries)", len(new_cache))
+        for name, value in new_cache.items():
+            self._publish_state(name, value)
+
+    def _publish_state(self, name, value):
+        payload = _format_value(value, self.settings[name]["step"])
+        self.client.publish(f"{self.state_topic_prefix}/{name}", payload, qos=0, retain=True)
+
+    # ----------------------------------------------------------------- requests
+
+    def request_read(self):
+        with self._lock:
+            self._raw_frames = [None] * self.frame_count
+            self._first_frame_at = None
+        try:
+            self.bus.send(
+                can.Message(
+                    arbitration_id=self.read_request_canid,
+                    data=self.read_request_data,
+                    is_extended_id=False,
+                )
+            )
+            logging.info(
+                "Sent BMS settings read request to 0x%X", self.read_request_canid
+            )
+        except Exception as e:
+            logging.error("Error sending BMS settings read request: %s", e)
+
+    # ---------------------------------------------------------------- MQTT side
+
+    def mqtt_subscriptions(self):
+        yield f"{self.state_topic_prefix}/+{self.command_topic_suffix}"
+        yield self.refresh_topic
+
+    def handle_mqtt(self, topic, payload):
+        if topic == self.refresh_topic:
+            self.request_read()
+            return True
+        prefix = self.state_topic_prefix + "/"
+        if topic.startswith(prefix) and topic.endswith(self.command_topic_suffix):
+            name = topic[len(prefix) : -len(self.command_topic_suffix)]
+            if name in self.settings:
+                self._handle_write(name, payload)
+                return True
+        return False
+
+    def _handle_write(self, name, payload):
+        entry = self.settings[name]
+        try:
+            value = float(payload.decode("utf-8").strip() if isinstance(payload, (bytes, bytearray)) else payload)
+        except Exception as e:
+            logging.error("BMS settings: cannot parse payload for %s: %r (%s)", name, payload, e)
+            return
+
+        if not self.cache_ready:
+            logging.error(
+                "BMS settings cache empty; dropping write to %s=%s (request a refresh first)",
+                name, value,
+            )
+            return
+
+        if entry["min"] is not None and value < entry["min"]:
+            logging.error("BMS settings: %s=%s below min %s", name, value, entry["min"])
+            return
+        if entry["max"] is not None and value > entry["max"]:
+            logging.error("BMS settings: %s=%s above max %s", name, value, entry["max"])
+            return
+
+        raw = round(value / entry["scale"])
+        try:
+            raw_bytes = raw.to_bytes(entry["size"], "big", signed=entry["signed"])
+        except OverflowError as e:
+            logging.error("BMS settings: %s=%s raw=%s does not fit %d-byte %s: %s",
+                          name, value, raw, entry["size"],
+                          "signed" if entry["signed"] else "unsigned", e)
+            return
+
+        with self._lock:
+            self.cache[name] = value
+            self._raw_frames[entry["frame_offset"]] = (
+                self._raw_frames[entry["frame_offset"]][: entry["byte_offset"]]
+                + raw_bytes
+                + self._raw_frames[entry["frame_offset"]][entry["byte_offset"] + entry["size"] :]
+            )
+            frames_to_send = list(self._raw_frames)
+
+        logging.info("BMS settings: writing %s=%s (raw=%s)", name, value, raw)
+        for i, data in enumerate(frames_to_send):
+            try:
+                self.bus.send(
+                    can.Message(
+                        arbitration_id=self.write_base + i,
+                        data=data,
+                        is_extended_id=False,
+                    )
+                )
+            except Exception as e:
+                logging.error("Error sending BMS settings write frame 0x%X: %s",
+                              self.write_base + i, e)
+                return
+            if self.inter_frame_delay > 0 and i < len(frames_to_send) - 1:
+                time.sleep(self.inter_frame_delay)
+
+        self._publish_state(name, value)
+
+    # ------------------------------------------------------------- HA discovery
+
+    def augment_ha_payload(self, ha_payload):
+        if not ha_payload:
+            return
+        cmps = ha_payload.setdefault("cmps", {})
+        for name, e in self.settings.items():
+            component = {
+                "p": "number",
+                "name": e["friendly_name"],
+                "state_topic": f"{self.state_topic_prefix}/{name}",
+                "command_topic": f"{self.state_topic_prefix}/{name}{self.command_topic_suffix}",
+                "unique_id": f"{self.unique_id_prefix}-setting-{name}",
+                "value_template": "{{ value }}",
+            }
+            if e["unit"]:
+                component["unit_of_measurement"] = e["unit"]
+            if e["min"] is not None:
+                component["min"] = e["min"]
+            if e["max"] is not None:
+                component["max"] = e["max"]
+            if e["step"] is not None:
+                component["step"] = e["step"]
+            if e["device_class"]:
+                component["device_class"] = e["device_class"]
+            cmps[f"setting_{name}"] = component
+
+        cmps["bms_settings_refresh"] = {
+            "p": "button",
+            "name": "Refresh BMS Settings",
+            "command_topic": self.refresh_topic,
+            "payload_press": "1",
+            "unique_id": f"{self.unique_id_prefix}-settings-refresh",
+            "icon": "mdi:refresh",
+        }
+
+    # ------------------------------------------------------------- can.Listener
+
+    def stop(self):
+        pass
+
+
+def _as_int(v):
+    if isinstance(v, int):
+        return v
+    return int(v, 0)
+
+
+def _format_value(value, step):
+    if isinstance(step, (int, float)) and 0 < step < 1:
+        decimals = max(0, -int(round(math.log10(step))))
+        return f"{value:.{decimals}f}"
+    if float(value).is_integer():
+        return str(int(value))
+    return f"{value:g}"

--- a/can2mqtt/can2mqtt.py
+++ b/can2mqtt/can2mqtt.py
@@ -24,6 +24,7 @@ import can
 import paho.mqtt.client as mqtt
 
 import can2mqtt_vias as vias
+from bms_settings import BmsSettings
 
 class RepeatedTimer:
     """Repeat `function` every `interval` seconds."""
@@ -256,6 +257,8 @@ def main():
             client.publish(birth_topic, payload=birth_payload, qos=1, retain=True)
             if ha_payload:
                 client.publish(ha_discovery_topic, payload=json.dumps(ha_payload), qos=1, retain=False)
+            if userdata[2] is not None:
+                userdata[2].request_read()
         else:
            logging.critical(f"Failed to connect to mqtt broker: {reason_code}")
 
@@ -266,6 +269,9 @@ def main():
     def on_message(client, userdata, message):
         CANBus= userdata[0]
         transmitters= userdata[1]
+        bms_settings= userdata[2]
+        if bms_settings is not None and bms_settings.handle_mqtt(message.topic, message.payload):
+            return
         for sub in filter(lambda sub: mqtt.topic_matches_sub(sub, message.topic), transmitters.keys()):
             tmtrs= transmitters[sub]
             for tmtr in tmtrs:
@@ -438,7 +444,22 @@ def main():
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect
 
-    client.user_data_set((bus, transmitters))
+    bms_settings = None
+    if jsoncfg.node_exists(c.bms_settings):
+        try:
+            bms_cfg = c.bms_settings(None)
+            ids = (ha_payload or {}).get("dev", {}).get("ids") if ha_payload else None
+            unique_id_prefix = ids or ha_discovery_device
+            bms_settings = BmsSettings(bms_cfg, bus, client, unique_id_prefix)
+            notifier.add_listener(bms_settings)
+            if ha_payload:
+                bms_settings.augment_ha_payload(ha_payload)
+            logging.info("BMS settings module loaded with %d entries", len(bms_settings.settings))
+        except Exception as e:
+            logging.error("Could not load bms_settings: %s", e)
+            bms_settings = None
+
+    client.user_data_set((bus, transmitters, bms_settings))
     try:
         mqtt_errno= client.connect(args.mqtt_host, args.mqtt_port, 60)
         if mqtt_errno!=0:
@@ -458,6 +479,12 @@ def main():
             client.subscribe(s)
         except BaseException as e:
             logging.error("Error adding subscribtion \"%s\": %s" % (s, e))
+    if bms_settings is not None:
+        for s in bms_settings.mqtt_subscriptions():
+            try:
+                client.subscribe(s)
+            except BaseException as e:
+                logging.error("Error adding bms_settings subscription \"%s\": %s" % (s, e))
 
     if jsoncfg.node_exists(c.canopen.sync_interval):
         logging.info("Adding CANopen sync master")

--- a/config.json.example
+++ b/config.json.example
@@ -37,6 +37,52 @@
 //            exact_match: true // not implemented yet
         },
     ],
+    // bms_settings: BMS user-configurable settings exposed over MQTT + HA discovery.
+    // Behavior:
+    //   - On MQTT connect, send `read_request_canid` with `read_request_data` to ask
+    //     the BMS to report all settings.
+    //   - Listen for `frame_count` response frames starting at `read_response_base`.
+    //     Once a complete set arrives, decode each entry and publish to
+    //     `{state_topic_prefix}/{name}` (retained).
+    //   - When a write arrives on `{state_topic_prefix}/{name}{command_topic_suffix}`,
+    //     update the cache and resend all `frame_count` frames starting at `write_base`.
+    //     Writes are DROPPED with an error if no successful read has populated the cache.
+    //   - Publishing anything to `refresh_topic` re-issues the read request.
+    bms_settings: {
+        read_request_canid: "0x500",
+        read_request_data: "AAAA0200FFFFFFFF",
+        read_response_base: "0x450",
+        write_base: "0x410",
+        frame_count: 11,
+        state_topic_prefix: "bms/settings",
+        command_topic_suffix: "/set",
+        refresh_topic: "bms/settings/refresh",
+        inter_frame_delay_ms: 10,
+        // Each entry: where the value lives in the multi-frame payload + scaling + HA hints.
+        // engineering_value = raw_int * scale; raw_int is big-endian, signed if specified.
+        settings: {
+            AH: {
+                frame_offset: 0, byte_offset: 0, size: 2, signed: false,
+                scale: 0.1, unit: "Ah",
+                min: 0, max: 500, step: 0.1,
+                friendly_name: "Battery Capacity"
+            },
+            cvol_h1: {
+                frame_offset: 4, byte_offset: 0, size: 2, signed: false,
+                scale: 0.001, unit: "V",
+                min: 2.0, max: 4.5, step: 0.001,
+                device_class: "voltage",
+                friendly_name: "Cell Overvoltage Alarm L1"
+            },
+            ch_temp_l3: {
+                frame_offset: 5, byte_offset: 6, size: 1, signed: true,
+                scale: 1, unit: "°C",
+                min: -40, max: 40, step: 1,
+                device_class: "temperature",
+                friendly_name: "Charge Low-Temp Alarm L3"
+            },
+        }
+    },
     hadiscovery: {
         discovery_prefix: "homeassistant",
         discovery_device_name: "can_bridge_can0",


### PR DESCRIPTION
New optional bms_settings config section enables reading and modifying the BMS user-configurable settings via MQTT and Home Assistant. The protocol uses one read-request frame plus N response frames; writes re-send all N frames built from a cached payload, so writes are dropped with an error if no successful read has populated the cache yet.

Each setting is auto-exposed as an HA `number` entity (plus a refresh `button`) via the existing hadiscovery payload.